### PR TITLE
Added headers to type and request return

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -98,6 +98,7 @@ export default class NetsuiteApiClient {
       const response = await got(uri, options);
       return {
         ...response,
+        headers: response.headers,
         data: response.body ? JSON.parse(response.body) : null,
       } as NetsuiteResponse;
     } catch (e) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type NetsuiteRequestOptions = {
 
 export type NetsuiteResponse = {
   statusCode: number;
+  headers: any;
   data: any;
 };
 


### PR DESCRIPTION
Added headers explicitly to the request return. Need this as several NetSuite requests (InventoryAdjustment, etc) return path to newly created record as the location key in the headers. The existing spread operation is not returning headers in the response as expected; response.headers was undefined.

