### PR TITLE
Allow override values for got request options

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -70,7 +70,7 @@ export default class NetsuiteApiClient {
    * @returns
    */
   public async request(opts: NetsuiteRequestOptions) {
-    const { path = "*", method = "GET", body = "", heads = {}, restletUrl } = opts;
+    const { path = "*", method = "GET", body = "", heads = {}, restletUrl, overrides = {} } = opts;
     const cleanPath = removeLeadingSlash(path);
     // Set up the Request URI
 
@@ -91,6 +91,7 @@ export default class NetsuiteApiClient {
       headers: this.getAuthorizationHeader(uri, method),
       throwHttpErrors: true,
       decompress: true,
+      ...overrides,
     } as OptionsOfTextResponseBody;
 
     if (Object.keys(heads).length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { OptionsOfTextResponseBody } from "got";
 import type {Buffer} from "node:buffer";
 import type {Readable} from "node:stream";
 
@@ -23,6 +24,10 @@ type BaseRequestOptions = {
      * Additional headers to send with the request
      */
     heads?: any;
+    /**
+     * These will override the options that are passed to the request library
+     */
+    overrides?: OptionsOfTextResponseBody
 };
 
 export type NetsuiteRequestOptions =


### PR DESCRIPTION
Thanks for creating this library it's very convenient for interacting with Netsuites REST API in node!

The issue I'm having is that the library passes the option `throwHttpError: true` to the got library. In the project I'm working on I want to handle certain error types differently and the most consistent want to do that is to look at the http response codes rather than comparing to string error messages which is the only option currently.

This change is to allow the person making the request to override the got options to get the desired behaviour.

I'm not completely sure this is the best solution as a user could override the auth headers so it might be better to only allow the user to override a subset of the fields.

Let me know what you think!

